### PR TITLE
Changing loading text when clicking 'Preview/Data Transfer' button

### DIFF
--- a/Colso.DataTransporter/DataTransporter.cs
+++ b/Colso.DataTransporter/DataTransporter.cs
@@ -848,7 +848,7 @@ namespace Colso.DataTransporter
 
             WorkAsync(new WorkAsyncInfo
             {
-                Message = "Transfering records...",
+                Message = preview ? "Analyzing differences..." : "Transfering records...",
                 AsyncArgument = lvEntities.SelectedItems.Cast<ListViewItem>().Select(v => (EntityMetadata)v.Tag).ToList(),
                 IsCancelable = true,
                 Work = (worker, evt) =>


### PR DESCRIPTION
Displaying the text 'Analyzing differences' or 'Transfering records' according to the button clicked.

Respectively:
'Preview' button displays text: 'Analyzing differences';
![image](https://user-images.githubusercontent.com/118485480/217625528-778aa587-b5f4-47e0-92ca-4f9f0327be32.png)

'Transfer Data' button displays the text: 'Transfering records'
![image](https://user-images.githubusercontent.com/118485480/217625619-86947014-424c-419f-975f-25aa0bd0c26e.png)
